### PR TITLE
Customize code block class

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ This extension contributes the following settings:
 * `wordpress-post.typeAttachedImageSlug` : Processing rules for attached image file names.
 * `wordpress-post.mediaTypes` : File extensions and media types to enable.
 * `wordpress-post.useLinkableImage` : Add a tag to img tag.
+* `wordpress-post.codeBlockLanguagePrefix` : Prefix of class name for code block
+* `wordpress-post.codeBlockTag` : HTML tag which specifies language class
 * `wordpress-post.debug` : Debug of this extension.
 
 My setting.json is:

--- a/package.json
+++ b/package.json
@@ -109,6 +109,24 @@
           "default": false,
           "description": "Add a tag to img tag"
         },
+        "wordpress-post.codeBlockLanguagePrefix": {
+          "type": "string",
+          "default": "language-",
+          "description": "Prefix of class name for code block"
+        },
+        "wordpress-post.codeBlockTag": {
+          "type": "string",
+          "default": "code",
+          "description" : "HTML tag which specifies language class",
+          "enum" : [
+            "code",
+            "pre"
+          ],
+          "enumDescriptions": [
+            "Add class for language to <code> tag",
+            "Add class for language to <pre> tag"
+          ]
+        },
         "wordpress-post.debug": {
           "type": "boolean",
           "default": false,

--- a/src/context.ts
+++ b/src/context.ts
@@ -112,6 +112,22 @@ export class Context {
     return this.getConf("useLinkableImage");
   }
 
+  /**
+   * Code Block
+   */
+  getCodeBlockStartTag(lang: string) : string {
+    const prefix:string = this.getConf("codeBlockLanguagePrefix");
+    const tag:string = this.getConf("codeBlockTag");
+    if ( tag === "pre" ) {
+      return "<pre class=\"" + prefix + lang + "\"><code>";
+    } else {
+      return "<pre><code class=\"" + prefix + lang + "\">";
+    }
+  }
+  getCodeBlockEndTag() : string {
+    return "</code></pre>";
+  }
+
   getConf(id: string): any {
     return vscode.workspace.getConfiguration(this.prefixOfSettings).get(id);
   }

--- a/src/post.ts
+++ b/src/post.ts
@@ -70,7 +70,7 @@ export const post = async (context: Context) => {
 
   // markdown -> post data content
   context.debug(`[06S] convert to html`);
-  var md = require('markdown-it')({
+  const md = require('markdown-it')({
     highlight: function (str: string, lang: string) {
       return context.getCodeBlockStartTag(lang) + md.utils.escapeHtml(str) + context.getCodeBlockEndTag();
     }

--- a/src/post.ts
+++ b/src/post.ts
@@ -2,7 +2,6 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import axios from "axios";
-import MarkdownIt = require("markdown-it");
 import * as matter from "gray-matter";
 import * as cheerio from "cheerio";
 import { Context } from "./context";
@@ -71,7 +70,12 @@ export const post = async (context: Context) => {
 
   // markdown -> post data content
   context.debug(`[06S] convert to html`);
-  postData["content"] = MarkdownIt().render(markdown.content);
+  var md = require('markdown-it')({
+    highlight: function (str: string, lang: string) {
+      return context.getCodeBlockStartTag(lang) + md.utils.escapeHtml(str) + context.getCodeBlockEndTag();
+    }
+  });
+  postData["content"] = md.render(markdown.content);
   context.debug(`[06E] converted to html`);
 
   // upload attached image file, change src


### PR DESCRIPTION
Markdownのコードブロックから生成されるHTMLを変更できるようにしました。

元々のコードでは
````
```c
int main(int argc, char* argv[]) {
    printf("hello world\n");
    return 0;
}
```
````
とすると、次のようなHTMLが生成されます。
```HTML
<pre><code class="language-c">int main(int argc, char* argv[]) {
    printf("hello world\n");
    return 0;
}
</code></pre>
```

使用しているWordPressのSyntaxHighlighterによっては、うまく認識しない場合があります。そこで、

* 言語のclass名のプリフィックス
* 言語をclassをつけるHTMLタグ

を変更できるようにしてみました。
(デフォルトでは従来と同じHTMLが生成されるようにしています)

生成されるHTMLの変更はMarkdown-itのhighlightオプションに関数を渡すことで実現しています。
Markdown-itの初期化時にこのオプションを変更するために、Markdown-itの取り込みを、ソースファイル冒頭のimportから関数中でのrequireに変更しています。

